### PR TITLE
Support cortex m33 FeeRTOS register stackings

### DIFF
--- a/src/rtos/FreeRTOS.c
+++ b/src/rtos/FreeRTOS.c
@@ -37,9 +37,7 @@ struct freertos_params {
 	const unsigned char list_elem_content_offset;
 	const unsigned char thread_stack_offset;
 	const unsigned char thread_name_offset;
-	const struct rtos_register_stacking *stacking_info_cm3;
-	const struct rtos_register_stacking *stacking_info_cm4f;
-	const struct rtos_register_stacking *stacking_info_cm4f_fpu;
+	const struct rtos_register_stacking* (*fn_get_stacking_info)(const struct rtos *rtos, int64_t stack_ptr);
 };
 
 static const struct freertos_params freertos_params_list[] = {
@@ -53,9 +51,7 @@ static const struct freertos_params freertos_params_list[] = {
 	12,						/* list_elem_content_offset */
 	0,						/* thread_stack_offset; */
 	52,						/* thread_name_offset; */
-	&rtos_standard_cortex_m3_stacking,	/* stacking_info */
-	&rtos_standard_cortex_m4f_stacking,
-	&rtos_standard_cortex_m4f_fpu_stacking,
+	rtos_standard_cortex_m_stacking_get /* fn_get_stacking_info */
 	},
 	{
 	"hla_target",			/* target_name */
@@ -67,9 +63,7 @@ static const struct freertos_params freertos_params_list[] = {
 	12,						/* list_elem_content_offset */
 	0,						/* thread_stack_offset; */
 	52,						/* thread_name_offset; */
-	&rtos_standard_cortex_m3_stacking,	/* stacking_info */
-	&rtos_standard_cortex_m4f_stacking,
-	&rtos_standard_cortex_m4f_fpu_stacking,
+	rtos_standard_cortex_m_stacking_get /* fn_get_stacking_info */
 	},
 };
 
@@ -418,45 +412,13 @@ static int freertos_get_thread_reg_list(struct rtos *rtos, int64_t thread_id,
 										thread_id + param->thread_stack_offset,
 										stack_ptr);
 
-	/* Check for armv7m with *enabled* FPU, i.e. a Cortex-M4F */
-	int cm4_fpu_enabled = 0;
-	struct armv7m_common *armv7m_target = target_to_armv7m(rtos->target);
-	if (is_armv7m(armv7m_target)) {
-		if ((armv7m_target->fp_feature == FPV4_SP) || (armv7m_target->fp_feature == FPV5_SP) ||
-				(armv7m_target->fp_feature == FPV5_DP)) {
-			/* Found ARM v7m target which includes a FPU */
-			uint32_t cpacr;
-
-			retval = target_read_u32(rtos->target, FPU_CPACR, &cpacr);
-			if (retval != ERROR_OK) {
-				LOG_ERROR("Could not read CPACR register to check FPU state");
-				return -1;
-			}
-
-			/* Check if CP10 and CP11 are set to full access. */
-			if (cpacr & 0x00F00000) {
-				/* Found target with enabled FPU */
-				cm4_fpu_enabled = 1;
-			}
-		}
+	const struct rtos_register_stacking *stacking_info =
+			param->fn_get_stacking_info(rtos, stack_ptr);
+	if (!stacking_info) {
+		LOG_ERROR("Unknown stacking info for thread id=0x%" PRIx64, (uint64_t)thread_id);
+		return -6;
 	}
-
-	if (cm4_fpu_enabled == 1) {
-		/* Read the LR to decide between stacking with or without FPU */
-		uint32_t lr_svc = 0;
-		retval = target_read_u32(rtos->target,
-				stack_ptr + 0x20,
-				&lr_svc);
-		if (retval != ERROR_OK) {
-			LOG_OUTPUT("Error reading stack frame from FreeRTOS thread");
-			return retval;
-		}
-		if ((lr_svc & 0x10) == 0)
-			return rtos_generic_stack_read(rtos->target, param->stacking_info_cm4f_fpu, stack_ptr, reg_list, num_regs);
-		else
-			return rtos_generic_stack_read(rtos->target, param->stacking_info_cm4f, stack_ptr, reg_list, num_regs);
-	} else
-		return rtos_generic_stack_read(rtos->target, param->stacking_info_cm3, stack_ptr, reg_list, num_regs);
+	return rtos_generic_stack_read(rtos->target, stacking_info, stack_ptr, reg_list, num_regs);
 }
 
 static int freertos_get_symbol_list_to_lookup(struct symbol_table_elem *symbol_list[])

--- a/src/rtos/ThreadX.c
+++ b/src/rtos/ThreadX.c
@@ -135,9 +135,9 @@ static const struct threadx_params threadx_params_list[] = {
 	40,							/* thread_name_offset; */
 	48,							/* thread_state_offset; */
 	136,						/* thread_next_offset */
-	&rtos_standard_cortex_m3_stacking,	/* stacking_info */
+	NULL,	          /* stacking_info */
 	1,							/* stacking_info_nb */
-	NULL,						/* fn_get_stacking_info */
+	rtos_standard_cortex_m_stacking_get,	/* fn_get_stacking_info */
 	NULL,						/* fn_is_thread_id_valid */
 	},
 	{
@@ -171,9 +171,9 @@ static const struct threadx_params threadx_params_list[] = {
 	40,							/* thread_name_offset; */
 	48,							/* thread_state_offset; */
 	136,						/* thread_next_offset */
-	&rtos_standard_cortex_m3_stacking,	/* stacking_info */
+	NULL,           /* stacking_info */
 	1,							/* stacking_info_nb */
-	NULL,						/* fn_get_stacking_info */
+	&rtos_standard_cortex_m_stacking_get,	/* fn_get_stacking_info */
 	NULL,						/* fn_is_thread_id_valid */
 	},
 };

--- a/src/rtos/rtos_standard_stackings.c
+++ b/src/rtos/rtos_standard_stackings.c
@@ -75,23 +75,43 @@ static const struct stack_register_offset rtos_standard_cortex_m4f_fpu_stack_off
 };
 
 static const struct stack_register_offset rtos_standard_cortex_m33_stack_offsets[] = {
-	{ ARMV7M_R0,   0x24, 32 },		/* r0   */
-	{ ARMV7M_R1,   0x28, 32 },		/* r1   */
-	{ ARMV7M_R2,   0x2c, 32 },		/* r2   */
-	{ ARMV7M_R3,   0x30, 32 },		/* r3   */
-	{ ARMV7M_R4,   0x04, 32 },		/* r4   */
-	{ ARMV7M_R5,   0x08, 32 },		/* r5   */
-	{ ARMV7M_R6,   0x0c, 32 },		/* r6   */
-	{ ARMV7M_R7,   0x10, 32 },		/* r7   */
-	{ ARMV7M_R8,   0x14, 32 },		/* r8   */
-	{ ARMV7M_R9,   0x18, 32 },		/* r9   */
-	{ ARMV7M_R10,  0x1c, 32 },		/* r10  */
-	{ ARMV7M_R11,  0x20, 32 },		/* r11  */
-	{ ARMV7M_R12,  0x34, 32 },		/* r12  */
+	{ ARMV7M_R0,   0x28, 32 },		/* r0   */
+	{ ARMV7M_R1,   0x2c, 32 },		/* r1   */
+	{ ARMV7M_R2,   0x30, 32 },		/* r2   */
+	{ ARMV7M_R3,   0x34, 32 },		/* r3   */
+	{ ARMV7M_R4,   0x08, 32 },		/* r4   */
+	{ ARMV7M_R5,   0x0C, 32 },		/* r5   */
+	{ ARMV7M_R6,   0x10, 32 },		/* r6   */
+	{ ARMV7M_R7,   0x14, 32 },		/* r7   */
+	{ ARMV7M_R8,   0x18, 32 },		/* r8   */
+	{ ARMV7M_R9,   0x1C, 32 },		/* r9   */
+	{ ARMV7M_R10,  0x20, 32 },		/* r10  */
+	{ ARMV7M_R11,  0x24, 32 },		/* r11  */
+	{ ARMV7M_R12,  0x38, 32 },		/* r12  */
 	{ ARMV7M_R13,  -2,   32 },		/* sp   */
-	{ ARMV7M_R14,  0x38, 32 },		/* lr   */
-	{ ARMV7M_PC,   0x3c, 32 },		/* pc   */
-	{ ARMV7M_XPSR, 0x40, 32 },		/* xPSR */
+	{ ARMV7M_R14,  0x3c, 32 },		/* lr   */
+	{ ARMV7M_PC,   0x40, 32 },		/* pc   */
+	{ ARMV7M_XPSR, 0x44, 32 },		/* xPSR */
+};
+
+static const struct stack_register_offset rtos_standard_cortex_m33_fpu_stack_offsets[] = {
+	{ ARMV7M_R0,   0x68, 32 },		/* r0   */
+	{ ARMV7M_R1,   0x6c, 32 },		/* r1   */
+	{ ARMV7M_R2,   0x70, 32 },		/* r2   */
+	{ ARMV7M_R3,   0x74, 32 },		/* r3   */
+	{ ARMV7M_R4,   0x08, 32 },		/* r4   */
+	{ ARMV7M_R5,   0x0C, 32 },		/* r5   */
+	{ ARMV7M_R6,   0x10, 32 },		/* r6   */
+	{ ARMV7M_R7,   0x14, 32 },		/* r7   */
+	{ ARMV7M_R8,   0x18, 32 },		/* r8   */
+	{ ARMV7M_R9,   0x1C, 32 },		/* r9   */
+	{ ARMV7M_R10,  0x20, 32 },		/* r10  */
+	{ ARMV7M_R11,  0x24, 32 },		/* r11  */
+	{ ARMV7M_R12,  0x78, 32 },		/* r12  */
+	{ ARMV7M_R13,  -2,   32 },		/* sp   */
+	{ ARMV7M_R14,  0x7c, 32 },		/* lr   */
+	{ ARMV7M_PC,   0x80, 32 },		/* pc   */
+	{ ARMV7M_XPSR, 0x84, 32 },		/* xPSR */
 };
 
 static const struct stack_register_offset rtos_standard_cortex_r4_stack_offsets[] = {
@@ -222,7 +242,16 @@ static target_addr_t rtos_standard_cortex_m33_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
 	target_addr_t stack_ptr)
 {
-	const int XPSR_OFFSET = 0x40;
+	const int XPSR_OFFSET = 0x44;
+	return rtos_cortex_m_stack_align(target, stack_data, stacking,
+		stack_ptr, XPSR_OFFSET);
+}
+
+static target_addr_t rtos_standard_cortex_m33_fpu_stack_align(struct target *target,
+	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
+	target_addr_t stack_ptr)
+{
+	const int XPSR_OFFSET = 0x84;
 	return rtos_cortex_m_stack_align(target, stack_data, stacking,
 		stack_ptr, XPSR_OFFSET);
 }
@@ -252,12 +281,20 @@ const struct rtos_register_stacking rtos_standard_cortex_m4f_fpu_stacking = {
 };
 
 static const struct rtos_register_stacking rtos_standard_cortex_m33_stacking = {
-	.stack_registers_size = 0x44,
+	.stack_registers_size = 0x48,
 	.stack_growth_direction = -1,
 	.num_output_registers = ARMV7M_NUM_CORE_REGS,
 	.calculate_process_stack = rtos_standard_cortex_m33_stack_align,
 	.register_offsets = rtos_standard_cortex_m33_stack_offsets
 };
+
+static const struct rtos_register_stacking rtos_standard_cortex_m33_fpu_stacking = {
+	.stack_registers_size = 0xD0,
+	.stack_growth_direction = -1,
+	.num_output_registers = ARMV7M_NUM_CORE_REGS,
+	.calculate_process_stack = rtos_standard_cortex_m33_fpu_stack_align,
+	.register_offsets = rtos_standard_cortex_m33_fpu_stack_offsets
+}; 
 
 const struct rtos_register_stacking rtos_standard_cortex_r4_stacking = {
 	.stack_registers_size = 0x48,
@@ -274,12 +311,6 @@ const struct rtos_register_stacking *
 	struct armv7m_common *armv7m_target = target_to_armv7m_safe(rtos->target);
 	if (!armv7m_target)
 		return NULL;
-
-	/* Detect an ARM v8M and return specific stacking */
-	if (armv7m_target->arm.arch == ARM_ARCH_V8M)
-		/* Future development may require floating point
-		 * and/or secure context... by now standard stacking */
-		return &rtos_standard_cortex_m33_stacking;
 
 	/* Detect the presence of FPU */
 	bool fpu_enabled = false;
@@ -298,18 +329,32 @@ const struct rtos_register_stacking *
 			fpu_enabled = true;
 	}
 	if (fpu_enabled) {
+		/* Detect an ARM v8M and return specific stacking */
+		bool armv8m = (armv7m_target->arm.arch == ARM_ARCH_V8M);
+
 		/* Read the LR that contains EXC_RETURN */
 		uint32_t exc_return = 0;
-		int retval = target_read_u32(rtos->target, stack_ptr + 0x20, &exc_return);
+		uint32_t stacked_lr_offset = armv8m ? 0x04 : 0x20;
+		int retval = target_read_u32(rtos->target, stack_ptr + stacked_lr_offset, &exc_return);
 		if (retval != ERROR_OK) {
 			LOG_OUTPUT("Error reading stack frame from rtos thread\n");
 			return NULL;
 		}
 		/* Check if the stack frame contains FPU registers */
-		if ((exc_return & 0x10) == 0)
-			return &rtos_standard_cortex_m4f_fpu_stacking;
-		else
+		bool fpuStacked = (exc_return & 0x10) == 0;
+
+		if (armv8m) {
+			if (fpuStacked) {
+				return &rtos_standard_cortex_m33_fpu_stacking;
+			}
+			return &rtos_standard_cortex_m33_stacking; 
+		}
+		else {
+			if (fpuStacked) {
+				return &rtos_standard_cortex_m4f_fpu_stacking;	
+			}
 			return &rtos_standard_cortex_m4f_stacking;
+		}
 	} else {
 		return &rtos_standard_cortex_m3_stacking;
 	}

--- a/src/rtos/rtos_standard_stackings.c
+++ b/src/rtos/rtos_standard_stackings.c
@@ -12,6 +12,7 @@
 #include "rtos.h"
 #include "target/armv7m.h"
 #include "rtos_standard_stackings.h"
+#include "target/cortex_m.h"
 
 static const struct stack_register_offset rtos_standard_cortex_m3_stack_offsets[ARMV7M_NUM_CORE_REGS] = {
 	{ ARMV7M_R0,   0x20, 32 },		/* r0   */
@@ -73,6 +74,25 @@ static const struct stack_register_offset rtos_standard_cortex_m4f_fpu_stack_off
 	{ ARMV7M_XPSR, 0x80, 32 },		/* xPSR */
 };
 
+static const struct stack_register_offset rtos_standard_cortex_m33_stack_offsets[] = {
+	{ ARMV7M_R0,   0x24, 32 },		/* r0   */
+	{ ARMV7M_R1,   0x28, 32 },		/* r1   */
+	{ ARMV7M_R2,   0x2c, 32 },		/* r2   */
+	{ ARMV7M_R3,   0x30, 32 },		/* r3   */
+	{ ARMV7M_R4,   0x04, 32 },		/* r4   */
+	{ ARMV7M_R5,   0x08, 32 },		/* r5   */
+	{ ARMV7M_R6,   0x0c, 32 },		/* r6   */
+	{ ARMV7M_R7,   0x10, 32 },		/* r7   */
+	{ ARMV7M_R8,   0x14, 32 },		/* r8   */
+	{ ARMV7M_R9,   0x18, 32 },		/* r9   */
+	{ ARMV7M_R10,  0x1c, 32 },		/* r10  */
+	{ ARMV7M_R11,  0x20, 32 },		/* r11  */
+	{ ARMV7M_R12,  0x34, 32 },		/* r12  */
+	{ ARMV7M_R13,  -2,   32 },		/* sp   */
+	{ ARMV7M_R14,  0x38, 32 },		/* lr   */
+	{ ARMV7M_PC,   0x3c, 32 },		/* pc   */
+	{ ARMV7M_XPSR, 0x40, 32 },		/* xPSR */
+};
 
 static const struct stack_register_offset rtos_standard_cortex_r4_stack_offsets[] = {
 	{ 0,  0x08, 32 },		/* r0  (a1)   */
@@ -198,6 +218,14 @@ static target_addr_t rtos_standard_cortex_m4f_fpu_stack_align(struct target *tar
 		stack_ptr, XPSR_OFFSET);
 }
 
+static target_addr_t rtos_standard_cortex_m33_stack_align(struct target *target,
+	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
+	target_addr_t stack_ptr)
+{
+	const int XPSR_OFFSET = 0x40;
+	return rtos_cortex_m_stack_align(target, stack_data, stacking,
+		stack_ptr, XPSR_OFFSET);
+}
 
 const struct rtos_register_stacking rtos_standard_cortex_m3_stacking = {
 	.stack_registers_size = 0x40,
@@ -207,7 +235,7 @@ const struct rtos_register_stacking rtos_standard_cortex_m3_stacking = {
 	.register_offsets = rtos_standard_cortex_m3_stack_offsets
 };
 
-const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking = {
+static const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking = {
 	.stack_registers_size = 0x44,
 	.stack_growth_direction = -1,
 	.num_output_registers = ARMV7M_NUM_CORE_REGS,
@@ -215,12 +243,20 @@ const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking = {
 	.register_offsets = rtos_standard_cortex_m4f_stack_offsets
 };
 
-const struct rtos_register_stacking rtos_standard_cortex_m4f_fpu_stacking = {
+static const struct rtos_register_stacking rtos_standard_cortex_m4f_fpu_stacking = {
 	.stack_registers_size = 0xcc,
 	.stack_growth_direction = -1,
 	.num_output_registers = ARMV7M_NUM_CORE_REGS,
 	.calculate_process_stack = rtos_standard_cortex_m4f_fpu_stack_align,
 	.register_offsets = rtos_standard_cortex_m4f_fpu_stack_offsets
+};
+
+static const struct rtos_register_stacking rtos_standard_cortex_m33_stacking = {
+	.stack_registers_size = 0x44,
+	.stack_growth_direction = -1,
+	.num_output_registers = ARMV7M_NUM_CORE_REGS,
+	.calculate_process_stack = rtos_standard_cortex_m33_stack_align,
+	.register_offsets = rtos_standard_cortex_m33_stack_offsets
 };
 
 const struct rtos_register_stacking rtos_standard_cortex_r4_stacking = {
@@ -230,3 +266,65 @@ const struct rtos_register_stacking rtos_standard_cortex_r4_stacking = {
 	.calculate_process_stack = rtos_generic_stack_align8,
 	.register_offsets = rtos_standard_cortex_r4_stack_offsets
 };
+
+static const struct rtos_register_stacking rtos_standard_nds32_n1068_stacking = {
+	.stack_registers_size = 0x90,
+	.stack_growth_direction = -1,
+	.num_output_registers = 32,
+	.calculate_process_stack = rtos_generic_stack_align8,
+	.register_offsets = rtos_standard_nds32_n1068_stack_offsets
+};
+
+const struct rtos_register_stacking *
+	rtos_standard_cortex_m_stacking_get(const struct rtos *rtos, int64_t stack_ptr)
+{
+	/* Check for armv7m with *enabled* FPU, i.e. a Cortex-M4F */
+	struct armv7m_common *armv7m_target = target_to_armv7m_safe(rtos->target);
+	if (!armv7m_target)
+		return NULL;
+
+	/* Detect an ARM v8M and return specific stacking */
+	if (armv7m_target->arm.arch == ARM_ARCH_V8M)
+		/* Future development may require floating point
+		 * and/or secure context... by now standard stacking */
+		return &rtos_standard_cortex_m33_stacking;
+
+	/* Detect the presence of FPU */
+	bool fpu_enabled = false;
+	if (armv7m_target->fp_feature == FPV4_SP ||
+	    armv7m_target->fp_feature == FPV5_SP ||
+	    armv7m_target->fp_feature == FPV5_DP) {
+		/* Found ARM v7m target which includes a FPU */
+		uint32_t cpacr;
+		int retval = target_read_u32(rtos->target, FPU_CPACR, &cpacr);
+		if (retval != ERROR_OK) {
+			LOG_ERROR("Could not read CPACR register to check FPU state");
+			return NULL;
+		}
+		/* Check if CP10 and CP11 are set to full access so FPU is enabled. */
+		if (cpacr & 0x00F00000)
+			fpu_enabled = true;
+	}
+	if (fpu_enabled) {
+		/* Read the LR that contains EXC_RETURN */
+		uint32_t exc_return = 0;
+		int retval = target_read_u32(rtos->target, stack_ptr + 0x20, &exc_return);
+		if (retval != ERROR_OK) {
+			LOG_OUTPUT("Error reading stack frame from rtos thread\n");
+			return NULL;
+		}
+		/* Check if the stack frame contains FPU registers */
+		if ((exc_return & 0x10) == 0)
+			return &rtos_standard_cortex_m4f_fpu_stacking;
+		else
+			return &rtos_standard_cortex_m4f_stacking;
+	} else {
+		return &rtos_standard_cortex_m3_stacking;
+	}
+}
+
+const struct rtos_register_stacking *
+	rtos_standard_nds32_stacking_get(const struct rtos *rtos, int64_t stack_ptr)
+{
+	return &rtos_standard_nds32_n1068_stacking;
+}

--- a/src/rtos/rtos_standard_stackings.c
+++ b/src/rtos/rtos_standard_stackings.c
@@ -235,7 +235,7 @@ const struct rtos_register_stacking rtos_standard_cortex_m3_stacking = {
 	.register_offsets = rtos_standard_cortex_m3_stack_offsets
 };
 
-static const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking = {
+const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking = {
 	.stack_registers_size = 0x44,
 	.stack_growth_direction = -1,
 	.num_output_registers = ARMV7M_NUM_CORE_REGS,
@@ -243,7 +243,7 @@ static const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking = {
 	.register_offsets = rtos_standard_cortex_m4f_stack_offsets
 };
 
-static const struct rtos_register_stacking rtos_standard_cortex_m4f_fpu_stacking = {
+const struct rtos_register_stacking rtos_standard_cortex_m4f_fpu_stacking = {
 	.stack_registers_size = 0xcc,
 	.stack_growth_direction = -1,
 	.num_output_registers = ARMV7M_NUM_CORE_REGS,
@@ -265,14 +265,6 @@ const struct rtos_register_stacking rtos_standard_cortex_r4_stacking = {
 	.num_output_registers = 26,
 	.calculate_process_stack = rtos_generic_stack_align8,
 	.register_offsets = rtos_standard_cortex_r4_stack_offsets
-};
-
-static const struct rtos_register_stacking rtos_standard_nds32_n1068_stacking = {
-	.stack_registers_size = 0x90,
-	.stack_growth_direction = -1,
-	.num_output_registers = 32,
-	.calculate_process_stack = rtos_generic_stack_align8,
-	.register_offsets = rtos_standard_nds32_n1068_stack_offsets
 };
 
 const struct rtos_register_stacking *
@@ -321,10 +313,4 @@ const struct rtos_register_stacking *
 	} else {
 		return &rtos_standard_cortex_m3_stacking;
 	}
-}
-
-const struct rtos_register_stacking *
-	rtos_standard_nds32_stacking_get(const struct rtos *rtos, int64_t stack_ptr)
-{
-	return &rtos_standard_nds32_n1068_stacking;
 }

--- a/src/rtos/rtos_standard_stackings.h
+++ b/src/rtos/rtos_standard_stackings.h
@@ -11,14 +11,19 @@
 #include "rtos.h"
 
 extern const struct rtos_register_stacking rtos_standard_cortex_m3_stacking;
-extern const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking;
-extern const struct rtos_register_stacking rtos_standard_cortex_m4f_fpu_stacking;
 extern const struct rtos_register_stacking rtos_standard_cortex_r4_stacking;
+
 target_addr_t rtos_generic_stack_align8(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
 	target_addr_t stack_ptr);
 target_addr_t rtos_cortex_m_stack_align(struct target *target,
 	const uint8_t *stack_data, const struct rtos_register_stacking *stacking,
 	target_addr_t stack_ptr, size_t xpsr_offset);
+
+const struct rtos_register_stacking *
+	rtos_standard_cortex_m_stacking_get(const struct rtos *rtos, int64_t stack_ptr);
+
+const struct rtos_register_stacking *
+	rtos_standard_nds32_stacking_get(const struct rtos *rtos, int64_t stack_ptr);
 
 #endif /* OPENOCD_RTOS_RTOS_STANDARD_STACKINGS_H */

--- a/src/rtos/rtos_standard_stackings.h
+++ b/src/rtos/rtos_standard_stackings.h
@@ -11,6 +11,8 @@
 #include "rtos.h"
 
 extern const struct rtos_register_stacking rtos_standard_cortex_m3_stacking;
+extern const struct rtos_register_stacking rtos_standard_cortex_m4f_stacking;
+extern const struct rtos_register_stacking rtos_standard_cortex_m4f_fpu_stacking;
 extern const struct rtos_register_stacking rtos_standard_cortex_r4_stacking;
 
 target_addr_t rtos_generic_stack_align8(struct target *target,
@@ -22,8 +24,5 @@ target_addr_t rtos_cortex_m_stack_align(struct target *target,
 
 const struct rtos_register_stacking *
 	rtos_standard_cortex_m_stacking_get(const struct rtos *rtos, int64_t stack_ptr);
-
-const struct rtos_register_stacking *
-	rtos_standard_nds32_stacking_get(const struct rtos *rtos, int64_t stack_ptr);
 
 #endif /* OPENOCD_RTOS_RTOS_STANDARD_STACKINGS_H */


### PR DESCRIPTION
Add register offsets for FreeRTOS register stackings with and without floating point contexts.
Detect which stacking is in place for each freertos thread.

See arm technical manual for gory details

![Screen Shot 2024-05-22 at 3 47 32 PM](https://github.com/particle-iot/openocd/assets/86268380/cde34023-39e2-4848-b800-ab8f125ec644)
