### PR TITLE
chore/sc-131532/update-openocd-gh-actions-since-macos-12

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,12 @@
+name: build-all-platforms
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!particle'
+
+jobs:
+  call-build:
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -24,8 +24,8 @@ jobs:
           name: artifact-mac-14-arm-release
           path: ./openocd
           if-no-files-found: error
-  build-mac-12:
-    runs-on: macos-12
+  build-mac-13:
+    runs-on: macos-13
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       - name: Publish OpenOCD packaged for mac
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: artifact-mac-12-release
+          name: artifact-mac-13-release
           path: ./openocd
           if-no-files-found: error
 

--- a/compress-release.sh
+++ b/compress-release.sh
@@ -12,7 +12,7 @@ map_artifact() {
     artifact-linux-20-04-release)
       echo "linux-x64"
       ;;
-    artifact-mac-12-release)
+    artifact-mac-13-release)
       echo "darwin-x64"
       ;;
     artifact-mac-14-arm-release)


### PR DESCRIPTION
Update github actions for macos building
Story details: https://app.shortcut.com/particle/story/131532